### PR TITLE
EDS 4.16 hsu fixes

### DIFF
--- a/drivers/dma/hsu/pci.c
+++ b/drivers/dma/hsu/pci.c
@@ -107,7 +107,7 @@ static int hsu_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	ret = request_irq(chip->irq, hsu_pci_irq, 0, "hsu_dma_pci", chip);
 	if (ret)
 		goto err_register_irq;
-
+	disable_irq_nosync(chip->irq);
 	pci_set_drvdata(pdev, chip);
 
 	return 0;

--- a/drivers/tty/serial/8250/8250.h
+++ b/drivers/tty/serial/8250/8250.h
@@ -47,6 +47,9 @@ struct uart_8250_dma {
 	unsigned char		tx_running;
 	unsigned char		tx_err;
 	unsigned char		rx_running;
+	
+	struct work_struct 	rx_workqueue;
+	struct uart_8250_port 	*up;
 };
 
 struct old_serial_port {

--- a/drivers/tty/serial/8250/8250.h
+++ b/drivers/tty/serial/8250/8250.h
@@ -39,6 +39,7 @@ struct uart_8250_dma {
 	dma_cookie_t		tx_cookie;
 
 	void			*rx_buf;
+	void			*tx_buf;
 
 	size_t			rx_size;
 	size_t			tx_size;

--- a/drivers/tty/serial/8250/8250_dma.c
+++ b/drivers/tty/serial/8250/8250_dma.c
@@ -67,6 +67,9 @@ int serial8250_tx_dma(struct uart_8250_port *p)
 	struct circ_buf			*xmit = &p->port.state->xmit;
 	struct dma_async_tx_descriptor	*desc;
 	int ret;
+	size_t				chunk1;
+	size_t 				chunk2;
+	int				head;
 
 	if (dma->tx_running)
 		return 0;
@@ -77,10 +80,18 @@ int serial8250_tx_dma(struct uart_8250_port *p)
 		return 0;
 	}
 
-	dma->tx_size = CIRC_CNT_TO_END(xmit->head, xmit->tail, UART_XMIT_SIZE);
+	head = xmit->head;
+	chunk1 = CIRC_CNT_TO_END(head, xmit->tail, UART_XMIT_SIZE);
+	memcpy(dma->tx_buf, xmit->buf + xmit->tail, chunk1);
+	
+	chunk2 = CIRC_CNT(head, xmit->tail, UART_XMIT_SIZE) - chunk1;
+	if(chunk2 > 0) {
+		memcpy(dma->tx_buf + chunk1, xmit->buf, chunk2);
+	}
+	dma->tx_size = chunk1 + chunk2;
 
 	desc = dmaengine_prep_slave_single(dma->txchan,
-					   dma->tx_addr + xmit->tail,
+					   dma->tx_addr,
 					   dma->tx_size, DMA_MEM_TO_DEV,
 					   DMA_PREP_INTERRUPT | DMA_CTRL_ACK);
 	if (!desc) {
@@ -222,8 +233,9 @@ int serial8250_request_dma(struct uart_8250_port *p)
 	}
 
 	/* TX buffer */
+	dma->tx_buf = kmalloc(UART_XMIT_SIZE, GFP_KERNEL);
 	dma->tx_addr = dma_map_single(dma->txchan->device->dev,
-					p->port.state->xmit.buf,
+					dma->tx_buf,
 					UART_XMIT_SIZE,
 					DMA_TO_DEVICE);
 	if (dma_mapping_error(dma->txchan->device->dev, dma->tx_addr)) {
@@ -262,6 +274,8 @@ void serial8250_release_dma(struct uart_8250_port *p)
 	dmaengine_terminate_sync(dma->txchan);
 	dma_unmap_single(dma->txchan->device->dev, dma->tx_addr,
 			 UART_XMIT_SIZE, DMA_TO_DEVICE);
+	if(dma->tx_buf) kfree(dma->tx_buf);
+	dma->tx_buf = NULL;
 	dma_release_channel(dma->txchan);
 	dma->txchan = NULL;
 	dma->tx_running = 0;


### PR DESCRIPTION
Hi Andy, here is what I have working now. I don't expect you to merge this yet. Although it works, it is still a hack enabled on ttyS1 only. But it is a big improvement, allowing 4Mb/s even while loading the kernel (I used iperf3 over usb->eth converter). But, I would like to here your comments and make it perfect, maybe eventually you could upstream this.

The 1st (linear buffer for transmit) you've seen before. The 2nd silences the hsu dma interrupt storm. The 3rd makes rx dma setup prior to reception instead of on interrupt of reception of first char. At 2Mb/s the interrupt latency was to large for the FIFO  length (on x86_64 at least), even without load.

The hack is of course I enabled this only on ttyS1. For some reason it breaks ttyS0 and ttyS2 if I enable on all. I think on the console ttyS0 dma is not enabled and ttyS2 is maybe a serdev and initialized different?