### PR TITLE
Hsu dma optimize

### DIFF
--- a/drivers/tty/serial/8250/8250.h
+++ b/drivers/tty/serial/8250/8250.h
@@ -41,6 +41,7 @@ struct uart_8250_dma {
 	dma_cookie_t		tx_cookie;
 
 	void			*rx_buf;
+	void			*tx_buf;
 
 	size_t			rx_size;
 	size_t			tx_size;

--- a/drivers/tty/serial/8250/8250_dma.c
+++ b/drivers/tty/serial/8250/8250_dma.c
@@ -8,6 +8,7 @@
 #include <linux/tty_flip.h>
 #include <linux/serial_reg.h>
 #include <linux/dma-mapping.h>
+#include <linux/slab.h>
 
 #include "8250.h"
 
@@ -65,6 +66,9 @@ int serial8250_tx_dma(struct uart_8250_port *p)
 	struct circ_buf			*xmit = &p->port.state->xmit;
 	struct dma_async_tx_descriptor	*desc;
 	int ret;
+	size_t				chunk1;
+	size_t 				chunk2;
+	int				head;
 
 	if (dma->tx_running)
 		return 0;
@@ -75,10 +79,18 @@ int serial8250_tx_dma(struct uart_8250_port *p)
 		return 0;
 	}
 
-	dma->tx_size = CIRC_CNT_TO_END(xmit->head, xmit->tail, UART_XMIT_SIZE);
+	head = xmit->head;
+	chunk1 = CIRC_CNT_TO_END(head, xmit->tail, UART_XMIT_SIZE);
+	memcpy(dma->tx_buf, xmit->buf + xmit->tail, chunk1);
+	
+	chunk2 = CIRC_CNT(head, xmit->tail, UART_XMIT_SIZE) - chunk1;
+	if(chunk2 > 0) {
+		memcpy(dma->tx_buf + chunk1, xmit->buf, chunk2);
+	}
+	dma->tx_size = chunk1 + chunk2;
 
 	desc = dmaengine_prep_slave_single(dma->txchan,
-					   dma->tx_addr + xmit->tail,
+					   dma->tx_addr,
 					   dma->tx_size, DMA_MEM_TO_DEV,
 					   DMA_PREP_INTERRUPT | DMA_CTRL_ACK);
 	if (!desc) {
@@ -217,8 +229,9 @@ int serial8250_request_dma(struct uart_8250_port *p)
 	}
 
 	/* TX buffer */
+	dma->tx_buf = kmalloc(UART_XMIT_SIZE, GFP_KERNEL);
 	dma->tx_addr = dma_map_single(dma->txchan->device->dev,
-					p->port.state->xmit.buf,
+					dma->tx_buf,
 					UART_XMIT_SIZE,
 					DMA_TO_DEVICE);
 	if (dma_mapping_error(dma->txchan->device->dev, dma->tx_addr)) {
@@ -257,6 +270,8 @@ void serial8250_release_dma(struct uart_8250_port *p)
 	dmaengine_terminate_sync(dma->txchan);
 	dma_unmap_single(dma->txchan->device->dev, dma->tx_addr,
 			 UART_XMIT_SIZE, DMA_TO_DEVICE);
+	kfree(dma->tx_buf);
+	dma->tx_buf = NULL;
 	dma_release_channel(dma->txchan);
 	dma->txchan = NULL;
 	dma->tx_running = 0;

--- a/drivers/tty/serial/8250/8250_dma.c
+++ b/drivers/tty/serial/8250/8250_dma.c
@@ -41,10 +41,8 @@ static void __dma_tx_complete(void *param)
 	spin_unlock_irqrestore(&p->port.lock, flags);
 }
 
-static void __dma_rx_complete(void *param)
+static void __dma_rx_complete(struct uart_8250_port *p, struct uart_8250_dma *dma)
 {
-	struct uart_8250_port	*p = param;
-	struct uart_8250_dma	*dma = p->dma;
 	struct tty_port		*tty_port = &p->port.state->port;
 	struct dma_tx_state	state;
 	int			count;
@@ -118,6 +116,15 @@ err:
 	return ret;
 }
 
+static void __dma_rx_rerun(void *param)
+{
+	struct uart_8250_port   *p = param;
+	struct uart_8250_dma	*dma = p->dma;
+
+	__dma_rx_complete(p, dma);
+	serial8250_rx_dma(p);
+}
+
 int serial8250_rx_dma(struct uart_8250_port *p)
 {
 	struct uart_8250_dma		*dma = p->dma;
@@ -133,7 +140,7 @@ int serial8250_rx_dma(struct uart_8250_port *p)
 		return -EBUSY;
 
 	dma->rx_running = 1;
-	desc->callback = __dma_rx_complete;
+	desc->callback = __dma_rx_rerun;
 	desc->callback_param = p;
 
 	dma->rx_cookie = dmaengine_submit(desc);
@@ -149,7 +156,7 @@ void serial8250_rx_dma_flush(struct uart_8250_port *p)
 
 	if (dma->rx_running) {
 		dmaengine_pause(dma->rxchan);
-		__dma_rx_complete(p);
+		__dma_rx_complete(p, dma);
 		dmaengine_terminate_async(dma->rxchan);
 	}
 }

--- a/drivers/tty/serial/8250/8250_mid.c
+++ b/drivers/tty/serial/8250/8250_mid.c
@@ -88,6 +88,8 @@ static int tng_handle_irq(struct uart_port *p)
 	err = hsu_dma_get_status(chip, mid->dma_index * 2 + 1, &status);
 	if (err > 0) {
 		serial8250_rx_dma_flush(up);
+		/* immediately after flushing arm dma again */
+		if (up->dma) up->dma->rx_dma(up);
 		ret |= 1;
 	} else if (err == 0)
 		ret |= hsu_dma_do_irq(chip, mid->dma_index * 2 + 1, status);
@@ -232,6 +234,34 @@ static void mid8250_set_termios(struct uart_port *p,
 	serial8250_do_set_termios(p, termios, old);
 }
 
+static int mid8250_startup(struct uart_port *port)
+{
+	struct uart_8250_port *up = up_to_u8250p(port);
+	struct mid8250 *mid = port->private_data;
+	int ret;
+
+	ret = serial8250_do_startup(port);
+	
+	/* arm rx dma at do_startup time
+	 * register new do_startup and do_shutdown
+	 * in mid8250_probe
+	 */
+
+	if (up->dma) up->dma->rx_dma(up);
+
+	return ret;
+}
+
+static void mid8250_shutdown(struct uart_port *port)
+{
+	struct uart_8250_port *up = up_to_u8250p(port);
+	struct mid8250 *mid = port->private_data;
+
+	if (up->dma) serial8250_rx_dma_flush(up);
+
+	serial8250_do_shutdown(port);
+}
+
 static bool mid8250_dma_filter(struct dma_chan *chan, void *param)
 {
 	struct hsu_dma_slave *s = param;
@@ -306,6 +336,8 @@ static int mid8250_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	uart.port.uartclk = mid->board->base_baud * 16;
 	uart.port.flags = UPF_SHARE_IRQ | UPF_FIXED_PORT | UPF_FIXED_TYPE;
 	uart.port.set_termios = mid8250_set_termios;
+	uart.port.startup = mid8250_startup;
+	uart.port.shutdown = mid8250_shutdown;
 
 	uart.port.mapbase = pci_resource_start(pdev, bar);
 	uart.port.membase = pcim_iomap(pdev, bar, 0);


### PR DESCRIPTION
I cleaned up "arm rx dma.." and hope it is now more clear. Also I enabled on all hsu ports that have dma enabled.
On the transmit side "use linear buffer..." the dma transmit still gets split up when the transfer is longer then 2048 (I see an additional interrupt occurring), but I don't know how to resolve that yet.