### PR TITLE
Another variant of transmit using sgl

### DIFF
--- a/drivers/tty/serial/8250/8250.h
+++ b/drivers/tty/serial/8250/8250.h
@@ -49,6 +49,9 @@ struct uart_8250_dma {
 	unsigned char		tx_running;
 	unsigned char		tx_err;
 	unsigned char		rx_running;
+
+	unsigned int		dma_tx_nents;
+	struct scatterlist	tx_sgl[2];
 };
 
 struct old_serial_port {

--- a/drivers/tty/tty_io.c
+++ b/drivers/tty/tty_io.c
@@ -170,7 +170,7 @@ static void free_tty_struct(struct tty_struct *tty)
 {
 	tty_ldisc_deinit(tty);
 	put_device(tty->dev);
-	kfree(tty->write_buf);
+	kvfree(tty->write_buf);
 	tty->magic = 0xDEADDEAD;
 	kfree(tty);
 }
@@ -997,9 +997,6 @@ static inline ssize_t do_tty_write(
 	 * layer has problems with bigger chunks. It will
 	 * claim to be able to handle more characters than
 	 * it actually does.
-	 *
-	 * FIXME: This can probably go away now except that 64K chunks
-	 * are too likely to fail unless switched to vmalloc...
 	 */
 	chunk = 2048;
 	if (test_bit(TTY_NO_WRITE_SPLIT, &tty->flags))
@@ -1014,12 +1011,12 @@ static inline ssize_t do_tty_write(
 		if (chunk < 1024)
 			chunk = 1024;
 
-		buf_chunk = kmalloc(chunk, GFP_KERNEL);
+		buf_chunk = kvmalloc(chunk, GFP_KERNEL | __GFP_RETRY_MAYFAIL);
 		if (!buf_chunk) {
 			ret = -ENOMEM;
 			goto out;
 		}
-		kfree(tty->write_buf);
+		kvfree(tty->write_buf);
 		tty->write_cnt = chunk;
 		tty->write_buf = buf_chunk;
 	}

--- a/drivers/usb/class/cdc-acm.c
+++ b/drivers/usb/class/cdc-acm.c
@@ -685,10 +685,6 @@ static int acm_port_activate(struct tty_port *port, struct tty_struct *tty)
 	if (retval)
 		goto error_get_interface;
 
-	/*
-	 * FIXME: Why do we need this? Allocating 64K of physically contiguous
-	 * memory is really nasty...
-	 */
 	set_bit(TTY_NO_WRITE_SPLIT, &tty->flags);
 	acm->control->needs_remote_wakeup = 1;
 


### PR DESCRIPTION
Can you please have a look at e3ffdfaf0eafb7040f75659b1dcc16e5e798cbf0?

It is based on https://elixir.bootlin.com/linux/latest/source/drivers/tty/serial/imx.c#L643 and behaves _exactly_ the same way as the version ce7c0cd9860eabb2353e8c2330ff253333b61028 you already took.

I think it looks cleaner but probably has more overhead.

The main thing I'm busting my brain on is, when I use my `hs_serial` program to test serial communication it works fine. But when I setup pppd between 2 Edisons and test using `iperf3` it hangs very quickly:
```
root@yuna:~# iperf3 -c 192.168.5.101 --bidir -t 0
Connecting to host 192.168.5.101, port 5201
[  6] local 192.168.5.100 port 53684 connected to 192.168.5.101 port 5201
[  8] local 192.168.5.100 port 53686 connected to 192.168.5.101 port 5201
[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
[  6][TX-C]   0.00-1.00   sec   107 KBytes   879 Kbits/sec    2   1.41 KBytes       
[  8][RX-C]   0.00-1.00   sec  24.0 KBytes   197 Kbits/sec                  
[  6][TX-C]   1.00-2.00   sec  0.00 Bytes  0.00 bits/sec    2   1.41 KBytes       
[  8][RX-C]   1.00-2.00   sec  0.00 Bytes  0.00 bits/sec                  
....
```
I hangs so badly that the only way to get serial working again is to reboot. I think (but not sure) that `dma->tx_running` is never cleared in a particular case, but I don't know how it's triggered by `pppd`.

When I do exactly the same without sgl but using a bounce buffer https://github.com/andy-shev/linux/pull/29/files `pppd / iperf3` works just fine.
